### PR TITLE
Update Direct Call action to support an optional detail

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -2169,11 +2169,22 @@
           "identifier": {
             "type": "string",
             "minLength": 1
+          },
+          "detail": {
+            "type": "string",
+            "minLength": 2
           }
         },
         "additionalProperties": false,
         "required": ["identifier"]
-      }
+      },
+      "transforms": [
+        {
+          "type": "function",
+          "propertyPath": "detail",
+          "parameters": ["event", "target"]
+        }
+      ]
     }
   ]
 }

--- a/src/lib/actions/directCall.js
+++ b/src/lib/actions/directCall.js
@@ -19,10 +19,20 @@ var window = require('@adobe/reactor-window');
  * @param {Object} settings Action settings.
  * @param {string} settings.identifier The identifier of the "Direct Call" Event Type that should
  * be called.
- * @param {Object} settings.payload The payload to be passed into the event object of the triggered rule.
+ * @param {Object} settings.detail The detail to be passed into the event object of the triggered
+ * rule.
+ * @param {Object} event The underlying event object that triggered the rule.
+ * @param {Object} event.element The element that the rule was targeting.
+ * @param {Object} event.target The element on which the event occurred.
  */
 module.exports = function (settings, event) {
   if (settings && settings.identifier) {
-    window._satellite.track(settings.identifier, settings.payload);
+    var detail = settings.detail;
+    if (detail) {
+      detail = detail.call(event.element, event, event.target);
+      window._satellite.track(settings.identifier, detail);
+    } else {
+      window._satellite.track(settings.identifier);
+    }
   }
 };

--- a/src/view/actions/__tests__/directCall.test.jsx
+++ b/src/view/actions/__tests__/directCall.test.jsx
@@ -12,6 +12,7 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import sharedTestingElements from '@test-helpers/react-testing-library';
 import createExtensionBridge from '@test-helpers/createExtensionBridge';
 import DirectCallIdentifier, { formConfig } from '../directCall';
 import bootstrap from '../../bootstrap';
@@ -62,5 +63,27 @@ describe('direct call action view', () => {
       pageElements.getIdentifierTextBox().hasAttribute('aria-invalid')
     ).toBeTrue();
     expect(extensionBridge.validate()).toBe(false);
+  });
+
+  it('allows user to provide custom detail', async () => {
+    extensionBridge.init({
+      settings: {
+        identifier: 'foo',
+        detail: 'return {bar: "baz"}'
+      }
+    });
+
+    spyOn(extensionBridge, 'openCodeEditor').and.callFake(() => ({
+      then(resolve) {
+        resolve('return {bar: "stamp"}');
+      }
+    }));
+
+    fireEvent.click(sharedTestingElements.customCodeEditor.getTriggerButton());
+
+    expect(extensionBridge.getSettings()).toEqual({
+      identifier: 'foo',
+      detail: 'return {bar: "stamp"}'
+    });
   });
 });

--- a/src/view/actions/directCall.jsx
+++ b/src/view/actions/directCall.jsx
@@ -11,8 +11,9 @@
  ****************************************************************************************/
 
 import React from 'react';
-import FullWidthField from '../components/fullWidthField';
 import EditorButton from '../components/editorButton';
+import FullWidthField from '../components/fullWidthField';
+import InfoTip from '../components/infoTip';
 import WrappedField from '../components/wrappedField';
 
 const DirectCall = () => (
@@ -24,15 +25,21 @@ const DirectCall = () => (
       isRequired
     />
 
-    <p>
-      The code you provide in the editor will be added to the call as the event detail. It has to be valid JSON.
-    </p>
+    <div className="u-gapTop">
+      <p>
+        (optional) The code that you provide in the editor will be run to
+        provide an event detail to the Direct Call.
+      </p>
 
-    <WrappedField
-      name="payload"
-      component={EditorButton}
-      language="javascript"
-    />
+      <WrappedField
+        name="detail"
+        component={EditorButton}
+        language="javascript"
+      />
+      <InfoTip placement="bottom">
+        Enter a script that returns a valid JavaScript key-value object.
+      </InfoTip>
+    </div>
   </>
 );
 
@@ -60,9 +67,7 @@ export const formConfig = {
       errors.identifier = 'Please specify an identifier.';
     }
 
-    if (!values.payload) {
-      errors.payload = 'Please provide custom script.';
-    }
+    // values.detail is optional, so skip its validation
 
     return errors;
   }


### PR DESCRIPTION
## Description

Updates #47 as follows:

- Renames "payload" to "detail" to better represent what the object is
- Transforms "detail" into a function that is expected to return the detail object
- Makes "detail" to be optional, as per `_satellite.track()`'s specification
- Adds and updates tests for views and module

## Related Issue

Issue #38

## Motivation and Context

See issue #38 description

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All tests pass and I've made any necessary test changes.
- [x] I have run the extension sandbox successfully.
